### PR TITLE
Implemented Pagination And Sorting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>MovieAPI</name>
 	<description>Spring boot project for building movie Restful api</description>
 	<properties>
-		<java.version>8</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -61,7 +61,15 @@
 					</excludes>
 				</configuration>
 			</plugin>
-		</plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
+            </plugin>
+        </plugins>
 	</build>
 
 </project>

--- a/src/main/java/com/movieflix/controller/MovieController.java
+++ b/src/main/java/com/movieflix/controller/MovieController.java
@@ -3,7 +3,9 @@ package com.movieflix.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.movieflix.dto.MovieDto;
+import com.movieflix.dto.MoviePageResponse;
 import com.movieflix.services.MovieService;
+import com.movieflix.utils.AppConstants;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -60,6 +62,24 @@ public class MovieController {
             throw new RuntimeException(e);
         }
 
+    }
+
+    @GetMapping("/allMoviePage")
+    public ResponseEntity<MoviePageResponse> getMovieWithPagination(
+            @RequestParam(defaultValue = AppConstants.PAGE_NUMBER, required = false) Integer pageNumber,
+            @RequestParam(defaultValue = AppConstants.PAGE_SIZE, required = false) Integer pageSize
+            ){
+        return ResponseEntity.ok(movieService.getAllMoviesWithPagination(pageNumber, pageSize));
+    }
+
+    @GetMapping("/allMoviePageSort")
+    public ResponseEntity<MoviePageResponse> getMovieWithPaginationAndSort(
+            @RequestParam(defaultValue = AppConstants.PAGE_NUMBER, required = false) Integer pageNumber,
+            @RequestParam(defaultValue = AppConstants.PAGE_SIZE, required = false) Integer pageSize,
+            @RequestParam(defaultValue = AppConstants.SORT_BY, required = false) String sortBy,
+            @RequestParam(defaultValue = AppConstants.SORT_DIR, required = false) String dir
+    ){
+        return ResponseEntity.ok(movieService.getAllMoviesWithPaginationAndSorting(pageNumber, pageSize,sortBy,dir));
     }
 
     private MovieDto convertMovieDto(String movieDtoObj) throws JsonProcessingException {

--- a/src/main/java/com/movieflix/dto/MoviePageResponse.java
+++ b/src/main/java/com/movieflix/dto/MoviePageResponse.java
@@ -1,0 +1,11 @@
+package com.movieflix.dto;
+
+import java.util.List;
+
+public record MoviePageResponse(List<MovieDto> movieDtos,
+                                Integer pageNumber,
+                                Integer pageSize,
+                                long totalElements,
+                                int totalPages,
+                                boolean isLast){
+}

--- a/src/main/java/com/movieflix/services/MovieService.java
+++ b/src/main/java/com/movieflix/services/MovieService.java
@@ -1,6 +1,7 @@
 package com.movieflix.services;
 
 import com.movieflix.dto.MovieDto;
+import com.movieflix.dto.MoviePageResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -17,6 +18,11 @@ public interface MovieService   {
         MovieDto updateMovie(Integer movieId, MovieDto movieDto, MultipartFile file) throws IOException;
 
         String deleteMovie(Integer movieId) throws IOException;
+
+        MoviePageResponse getAllMoviesWithPagination(Integer pageNumber, Integer pageSize);
+
+        MoviePageResponse getAllMoviesWithPaginationAndSorting(Integer pageNumber, Integer pageSize,
+                                                               String sortBy, String dir);
 
 
 }

--- a/src/main/java/com/movieflix/services/MovieServiceImpl.java
+++ b/src/main/java/com/movieflix/services/MovieServiceImpl.java
@@ -1,9 +1,14 @@
 package com.movieflix.services;
 
 import com.movieflix.dto.MovieDto;
+import com.movieflix.dto.MoviePageResponse;
 import com.movieflix.entity.Movie;
 import com.movieflix.repositories.MovieRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -174,5 +179,73 @@ public class MovieServiceImpl implements  MovieService{
 //        3. delete the movie object.
         movieRepository.delete(mv);
         return "Movie with ID: "+id+ " got deleted successfully...";
+    }
+
+    @Override
+    public MoviePageResponse getAllMoviesWithPagination(Integer pageNumber, Integer pageSize) {
+        // getting object of Pageable by passing pageNumber and pageSize.
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        // by calling findAll pageable we are getting the pages of Movie
+        // which have information like total number of elements totalpages.
+
+        Page<Movie> moviePages = movieRepository.findAll(pageable);
+        // retriving the content present in moviePages object.
+        List<Movie> movies = moviePages.getContent();
+
+        List<MovieDto> movieDtos = new ArrayList<>();
+        for (Movie movie:movies) {
+            String posterUrl = baseUrl + "/file/" + movie.getPoster();
+            MovieDto movieDto = new MovieDto(
+                    movie.getMovieId(),
+                    movie.getTitle(),
+                    movie.getDirector(),
+                    movie.getStudio(),
+                    movie.getMovieCast(),
+                    movie.getReleaseYear(),
+                    movie.getPoster(),
+                    posterUrl
+            );
+            movieDtos.add(movieDto);
+        }
+
+        return new  MoviePageResponse(movieDtos, pageNumber, pageSize,
+                                moviePages.getTotalElements(),
+                                moviePages.getTotalPages(),
+                                moviePages.isLast());
+    }
+
+    @Override
+    public MoviePageResponse getAllMoviesWithPaginationAndSorting(Integer pageNumber, Integer pageSize, String sortBy, String dir) {
+        Sort sort = Sort.by(dir.equalsIgnoreCase("asc") ? Sort.Order.asc(sortBy) : Sort.Order.desc(sortBy));
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, sort);
+        // by calling findAll pageable we are getting the pages of Movie
+        // which have information like total number of elements totalpages.
+
+        Page<Movie> moviePages = movieRepository.findAll(pageable);
+        // retriving the content present in moviePages object.
+        List<Movie> movies = moviePages.getContent();
+
+        List<MovieDto> movieDtos = new ArrayList<>();
+        for (Movie movie:movies) {
+            String posterUrl = baseUrl + "/file/" + movie.getPoster();
+            MovieDto movieDto = new MovieDto(
+                    movie.getMovieId(),
+                    movie.getTitle(),
+                    movie.getDirector(),
+                    movie.getStudio(),
+                    movie.getMovieCast(),
+                    movie.getReleaseYear(),
+                    movie.getPoster(),
+                    posterUrl
+            );
+            movieDtos.add(movieDto);
+
+        }
+
+        return new  MoviePageResponse(movieDtos, pageNumber, pageSize,
+                moviePages.getTotalElements(),
+                moviePages.getTotalPages(),
+                moviePages.isLast());
     }
 }

--- a/src/main/java/com/movieflix/utils/AppConstants.java
+++ b/src/main/java/com/movieflix/utils/AppConstants.java
@@ -1,0 +1,11 @@
+package com.movieflix.utils;
+
+public class AppConstants {
+    public static final String PAGE_NUMBER = "0";
+
+    public static final String PAGE_SIZE ="3";
+
+    public  static final String SORT_BY = "movieId";
+
+    public static final String SORT_DIR = "asc";
+}


### PR DESCRIPTION
## Description

Implemented endpoints for paginated movie retrieval with and without sorting.

### Changes Made

- Added `GET /allMoviePage` endpoint for paginated movie retrieval.
- Added `GET /allMoviePageSort` endpoint for paginated movie retrieval with sorting.

### Endpoints

1. **`GET /allMoviePage`**

   - Params:
     - `pageNumber`: Current page number (Default: 0).
     - `pageSize`: Number of items per page (Default: 3).

   - Returns:
     - Paginated list of movies.

2. **`GET /allMoviePageSort`**

   - Params:
     - `pageNumber`: Current page number (Default: 0).
     - `pageSize`: Number of items per page (Default: 3).
     - `sortBy`: Field to sort by (Default: movieId).
     - `dir`: Sorting direction, either "asc" or "desc" (Default: asc).

   - Returns:
     - Paginated and sorted list of movies.

### Constants Updated

- Updated default values for page number, page size, sort by, and sort direction in `AppConstants`.

### Service Implementation

- Added service methods:
  - `getAllMoviesWithPagination` for paginated movie retrieval.
  - `getAllMoviesWithPaginationAndSorting` for paginated movie retrieval with sorting.

### Usage

1. **Paginated Movie Retrieval:**
   ```bash
   GET /allMoviePage?pageNumber=1&pageSize=5

2. **Paginated and Sorted Movie Retrieval:**
   ```bash
   GET /allMoviePageSort?pageNumber=1&pageSize=5&sortBy=title&dir=asc
